### PR TITLE
Change .Net45 to use the Users store instead of global.

### DIFF
--- a/src/Plugin.Settings.Net45/Settings.cs
+++ b/src/Plugin.Settings.Net45/Settings.cs
@@ -13,7 +13,7 @@ namespace Plugin.Settings
     {
         private static IsolatedStorageFile Store
         {
-            get { return IsolatedStorageFile.GetMachineStoreForAssembly(); }
+            get { return IsolatedStorageFile.GetUserStoreForAssembly(); }
         }
 
         private readonly object locker = new object();


### PR DESCRIPTION
Changes Proposed in this pull request:
Change .Net45 to use the Users store instead of global.
Fixes a bug on OS X https://bugzilla.xamarin.com/show_bug.cgi?id=41910
