### PR TITLE
corrected typo in decimal error handling

### DIFF
--- a/src/Plugin.Settings.Android/Settings.cs
+++ b/src/Plugin.Settings.Android/Settings.cs
@@ -71,7 +71,7 @@ namespace Plugin.Settings
                         {
                             Console.WriteLine("Could not parse old value, will be lost.");
                         }
-                        Remove("key");
+                        Remove(key);
                         resave = true;
                     }
                     if (string.IsNullOrWhiteSpace(savedDecimal))


### PR DESCRIPTION
Fixes decimal error handling.

Changes Proposed in this pull request:
- code was trying to remove "key"
- code now removes the key passed in to the method