### PR TITLE
Add (Android) Application.Context null check

### DIFF
--- a/src/Plugin.Settings.Android/Settings.cs
+++ b/src/Plugin.Settings.Android/Settings.cs
@@ -35,14 +35,13 @@ namespace Plugin.Settings
 
             lock (locker)
             {
-				if (Application.Context == null)
-					return defaultValue;
+		if (Application.Context == null)
+			return defaultValue;
 
-				using (var sharedPreferences = PreferenceManager.GetDefaultSharedPreferences(Application.Context))
+		using (var sharedPreferences = PreferenceManager.GetDefaultSharedPreferences(Application.Context))
                 {
                     return GetValueOrDefaultCore(sharedPreferences, key, defaultValue);
                 }
-
             }
         }
 

--- a/src/Plugin.Settings.Android/Settings.cs
+++ b/src/Plugin.Settings.Android/Settings.cs
@@ -35,10 +35,10 @@ namespace Plugin.Settings
 
             lock (locker)
             {
-		if (Application.Context == null)
-			return defaultValue;
+                if (Application.Context == null)
+                    return defaultValue;
 
-		using (var sharedPreferences = PreferenceManager.GetDefaultSharedPreferences(Application.Context))
+                using (var sharedPreferences = PreferenceManager.GetDefaultSharedPreferences(Application.Context))
                 {
                     return GetValueOrDefaultCore(sharedPreferences, key, defaultValue);
                 }

--- a/src/Plugin.Settings.Android/Settings.cs
+++ b/src/Plugin.Settings.Android/Settings.cs
@@ -35,10 +35,14 @@ namespace Plugin.Settings
 
             lock (locker)
             {
-                using (var sharedPreferences = PreferenceManager.GetDefaultSharedPreferences(Application.Context))
+				if (Application.Context == null)
+					return defaultValue;
+
+				using (var sharedPreferences = PreferenceManager.GetDefaultSharedPreferences(Application.Context))
                 {
                     return GetValueOrDefaultCore(sharedPreferences, key, defaultValue);
                 }
+
             }
         }
 


### PR DESCRIPTION
Fixes Xamarin.Forms Previewer (Java.Lang.NullPointerException) breaking when trying to access properties.