### PR TITLE
Enhance value checks #60

### DIFF
--- a/src/Plugin.Settings.Android/Settings.cs
+++ b/src/Plugin.Settings.Android/Settings.cs
@@ -28,6 +28,11 @@ namespace Plugin.Settings
         /// <returns>Value or default</returns>
         public T GetValueOrDefault<T>(string key, T defaultValue = default(T))
         {
+            if (defaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(defaultValue), "Default value can not be null");
+            }
+
             lock (locker)
             {
                 using (var sharedPreferences = PreferenceManager.GetDefaultSharedPreferences(Application.Context))
@@ -182,7 +187,7 @@ namespace Plugin.Settings
                     }
                     else
                     {
-                        throw new ArgumentException(string.Format("Value of type {0} is not supported.", value.GetType().Name));
+                        throw new ArgumentException($"Value of type {typeCode} is not supported.");
                     }
 
                     break;
@@ -199,6 +204,11 @@ namespace Plugin.Settings
         /// <returns>True if added or update and you need to save</returns>
         public bool AddOrUpdateValue<T>(string key, T value)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value), "Value can not be null");
+            }
+
             Type typeOf = typeof(T);
             if (typeOf.IsGenericType && typeOf.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
@@ -254,8 +264,7 @@ namespace Plugin.Settings
                                 }
                                 else
                                 {
-                                    throw new ArgumentException(string.Format("Value of type {0} is not supported.",
-                                        value.GetType().Name));
+                                    throw new ArgumentException($"Value of type {typeCode} is not supported.");
                                 }
                                 break;
                         }

--- a/src/Plugin.Settings.WindowsPhone81/Settings.cs
+++ b/src/Plugin.Settings.WindowsPhone81/Settings.cs
@@ -28,6 +28,11 @@ namespace Plugin.Settings
         /// <returns>Value or default</returns>
         public T GetValueOrDefault<T>(string key, T defaultValue = default(T))
         {
+            if (defaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(defaultValue), "Default value can not be null");
+            }
+
             object value;
             lock (locker)
             {
@@ -107,6 +112,11 @@ namespace Plugin.Settings
         /// <returns>True if added or update and you need to save</returns>
         public bool AddOrUpdateValue<T>(string key, T value)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value), "Value can not be null");
+            }
+
             return InternalAddOrUpdateValue(key, value);
         }
         

--- a/src/Plugin.Settings.iOSUnified/Settings.cs
+++ b/src/Plugin.Settings.iOSUnified/Settings.cs
@@ -23,6 +23,11 @@ namespace Plugin.Settings
         /// <returns>Value or default</returns>
         public T GetValueOrDefault<T>(string key, T defaultValue = default(T))
         {
+            if(defaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(defaultValue), "Default value can not be null");
+            }
+
             lock (locker)
             {
                 var defaults = NSUserDefaults.StandardUserDefaults;
@@ -102,7 +107,7 @@ namespace Plugin.Settings
                         }
                         else
                         {
-                            throw new ArgumentException(string.Format("Value of type {0} is not supported.", value.GetType().Name));
+                            throw new ArgumentException($"Value of type {typeCode} is not supported.");
                         }
 
                         break;
@@ -121,6 +126,11 @@ namespace Plugin.Settings
         /// <returns>True if added or update and you need to save</returns>
         public bool AddOrUpdateValue<T>(string key, T value)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value), "Value can not be null");
+            }
+
             Type typeOf = typeof(T);
             if (typeOf.IsGenericType && typeOf.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
@@ -171,7 +181,7 @@ namespace Plugin.Settings
                         }
                         else
                         {
-                            throw new ArgumentException(string.Format("Value of type {0} is not supported.", value.GetType().Name));
+                            throw new ArgumentException($"Value of type {typeCode} is not supported.");
                         }
                         break;
                 }


### PR DESCRIPTION
Don't allow nulls to be passed int. Ensure type is passed up when not
supported.

Fixed issue when type can't be checked and value is null