### PR TITLE
Minor formatting in DataBindingToSettings.md file

### DIFF
--- a/docs/DataBindingToSettings.md
+++ b/docs/DataBindingToSettings.md
@@ -155,4 +155,5 @@ Notice that we are now inheriting from BaseViewModel, which means our command ca
 </StackLayout>
 ```
 Notice I am setting the BindingContext to our Settings, which is in our BaseViewModel for the Label, this must be done because that is where it is located now. And there you have it.
+
 <= Back to [Table of Contents](README.md)


### PR DESCRIPTION
Please take a moment to fill out the following:

Changes Proposed in this pull request:
- Back to table of content link is placed on new line in **DataBindingToSettings.md** file. Change is made to keep the position of back to table of content link consistent in each document.

@jamesmontemagno please review the pull request.  
