### PR TITLE
Auto key

### DIFF
--- a/docs/AccessSettings.md
+++ b/docs/AccessSettings.md
@@ -47,7 +47,45 @@ public static void SetDidPurchase(string key) =>
     AppSettings.AddOrUpdateValue("iap_" + key, true);
 ```
 
+## Key autodetection
+You can skip passing key directly and determine it from caller context (it can be name of method or property). Also you can skip passing default value, in this case it will be initial value of type. This feature is available as the *SettingsAutoKeyExtensions* class with extension methods in the *Plugin.Settings.Abstractions.Extensions* namespace. There are specific methods for each data type that can be passed in:
 
+```csharp
+
+/// <summary>
+/// Gets the current value or the default.
+/// </summary>
+/// <param name="settings">Settings instance</param>
+/// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+/// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+/// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+/// <returns>Value or default</returns>
+public static Int32 GetValueOrDefault(this ISettings settings, Int32 defaultValue = default(Int32), string fileName = null, [CallerMemberName] string key = null)
+=> settings.GetValueOrDefault(key, defaultValue, fileName);
+
+/// <summary>
+/// Adds or updates the value 
+/// </summary>
+/// <param name="settings">Settings instance</param>
+/// <param name="value">Value to set</param>
+/// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+/// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+/// <returns>True of was added or updated and you need to save it.</returns>
+public static bool AddOrUpdateValue(this ISettings settings, Int32 value, string fileName = null, [CallerMemberName] string key = null)
+=> settings.AddOrUpdateValue(key, value, fileName);
+```
+
+Example:
+```csharp
+using Plugin.Settings.Abstractions.Extensions;
+
+private static ISettings AppSettings => CrossSettings.Current;
+
+public static bool IsAppInitialized
+{
+  get => AppSettings.GetValueOrDefault(); 
+  set => AppSettings.AddOrUpdateValue(value); 
+}
 
 <= Back to [Table of Contents](README.md)
 

--- a/src/Plugin.Settings.Abstractions/Extensions/SettingsAutoKeyExtensions.cs
+++ b/src/Plugin.Settings.Abstractions/Extensions/SettingsAutoKeyExtensions.cs
@@ -1,0 +1,72 @@
+﻿
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Plugin.Settings.Abstractions.Extensions
+{
+    /// <summary>
+    /// Auto keys extensions for ISettings
+    /// </summary>
+    public static class SettingsAutoKeyExtensions
+    {
+        public static Decimal GetValueOrDefault(this ISettings settings, Decimal defaultValue = default(Decimal), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static Boolean GetValueOrDefault(this ISettings settings, Boolean defaultValue = default(Boolean), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static Int64 GetValueOrDefault(this ISettings settings, Int64 defaultValue = default(Int64), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static String GetValueOrDefault(this ISettings settings, String defaultValue = default(String), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static Int32 GetValueOrDefault(this ISettings settings, Int32 defaultValue = default(Int32), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static Single GetValueOrDefault(this ISettings settings, Single defaultValue = default(Single), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static DateTime GetValueOrDefault(this ISettings settings, DateTime defaultValue = default(DateTime), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static Guid GetValueOrDefault(this ISettings settings, Guid defaultValue = default(Guid), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static Double GetValueOrDefault(this ISettings settings, Double defaultValue = default(Double), string fileName = null, [CallerMemberName] string key = null)
+        => settings.GetValueOrDefault(key, defaultValue, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, Decimal value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, Boolean value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, Int64 value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, String value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, Int32 value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, Single value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, DateTime value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, Guid value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static bool AddOrUpdateValue(this ISettings settings, Double value, string fileName = null, [CallerMemberName] string key = null)
+        => settings.AddOrUpdateValue(key, value, fileName);
+
+        public static void Remove(this ISettings settings, string fileName = null, [CallerMemberName] string key = null)
+        => settings.Remove(key, fileName);
+
+        public static void Contains(this ISettings settings, string fileName, [CallerMemberName] string key = null)
+        => settings.Contains(key, fileName);
+    }
+}

--- a/src/Plugin.Settings.Abstractions/Extensions/SettingsAutoKeyExtensions.cs
+++ b/src/Plugin.Settings.Abstractions/Extensions/SettingsAutoKeyExtensions.cs
@@ -9,63 +9,221 @@ namespace Plugin.Settings.Abstractions.Extensions
     /// </summary>
     public static class SettingsAutoKeyExtensions
     {
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static Decimal GetValueOrDefault(this ISettings settings, Decimal defaultValue = default(Decimal), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static Boolean GetValueOrDefault(this ISettings settings, Boolean defaultValue = default(Boolean), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static Int64 GetValueOrDefault(this ISettings settings, Int64 defaultValue = default(Int64), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static String GetValueOrDefault(this ISettings settings, String defaultValue = default(String), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static Int32 GetValueOrDefault(this ISettings settings, Int32 defaultValue = default(Int32), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static Single GetValueOrDefault(this ISettings settings, Single defaultValue = default(Single), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static DateTime GetValueOrDefault(this ISettings settings, DateTime defaultValue = default(DateTime), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static Guid GetValueOrDefault(this ISettings settings, Guid defaultValue = default(Guid), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+        /// <summary>
+        /// Gets the current value or the default.
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="defaultValue">Default value if not set. By default it's initial value of type</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>Value or default</returns>
         public static Double GetValueOrDefault(this ISettings settings, Double defaultValue = default(Double), string fileName = null, [CallerMemberName] string key = null)
         => settings.GetValueOrDefault(key, defaultValue, fileName);
 
+
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, Decimal value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, Boolean value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, Int64 value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, String value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, Int32 value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, Single value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, DateTime value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, Guid value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Adds or updates the value 
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="value">Value to set</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for settings. By default it's caller's name (method or property)</param>
+        /// <returns>True of was added or updated and you need to save it.</returns>
         public static bool AddOrUpdateValue(this ISettings settings, Double value, string fileName = null, [CallerMemberName] string key = null)
         => settings.AddOrUpdateValue(key, value, fileName);
 
+        /// <summary>
+        /// Removes a record from settings by key
+        /// </summary>
+        /// <param name="settings">Settings instance</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key for removing. By default it's caller's name (method or property)</param>
         public static void Remove(this ISettings settings, string fileName = null, [CallerMemberName] string key = null)
         => settings.Remove(key, fileName);
 
+        /// <summary>
+        /// Checks to see if the key has been added.
+        /// </summary> 
+        /// <param name="settings">Settings instance</param>
+        /// <param name="fileName">Name of file for settings to be stored and retrieved </param>
+        /// <param name="key">Key to check. By default it's caller's name (method or property)</param>
+        /// <returns>True if contains key, else false</returns>
         public static void Contains(this ISettings settings, string fileName, [CallerMemberName] string key = null)
         => settings.Contains(key, fileName);
     }

--- a/src/Plugin.Settings.Abstractions/Plugin.Settings.Abstractions.csproj
+++ b/src/Plugin.Settings.Abstractions/Plugin.Settings.Abstractions.csproj
@@ -13,4 +13,7 @@
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi, thanks for this plugin. It's great!

So, as for my PR.
From my point of view, it would be useful to have opportunity to retrieve caller member name from context and use it as key, instead of directly writing key every time.

From my experience I usually create several static properties in the default Settings class and use them to realize storing/retrieving data.

So, according to this PR, we would reduce code's size
And will be able to write that

```csharp
        public static bool BoolProp // 104 characters
        {
            get => AppSettings.GetValueOrDefault();
            set => AppSettings.AddOrUpdateValue(value);
        }
```
instead of 

```csharp
        public static bool BoolProp // 143 characters
        {
            get => AppSettings.GetValueOrDefault(nameof(BoolProp), false);
            set => AppSettings.AddOrUpdateValue(nameof(BoolProp), value);
        }
```

you just need to add this line of code

```csharp
using Plugin.Settings.Abstractions.Extensions;
```

### PR Checklist ###

:pushpin: Has tests (All passed)
:pushpin: Rebased on top of master at time of PR
:pushpin: Consolidate commits as makes sense
