### PR TITLE
Removed Lazy, to allow people to set the current implementation

### DIFF
--- a/src/Plugin.Settings/CrossSettings.shared.cs
+++ b/src/Plugin.Settings/CrossSettings.shared.cs
@@ -18,14 +18,14 @@ namespace Plugin.Settings
     /// </summary>
     public static class CrossSettings
     {
-		static ISettings _implementation;
+		static ISettings implementation;
 
-		static ISettings implementation => _implementation ?? (_implementation = CreateSettings());
+		static ISettings Implementation => implementation ?? (implementation = CreateSettings());
 
         /// <summary>
         /// Gets if the plugin is supported on the current platform.
         /// </summary>
-        public static bool IsSupported => implementation == null ? false : true;
+        public static bool IsSupported => Implementation == null ? false : true;
 
         /// <summary>
         /// Current plugin implementation to use
@@ -34,7 +34,7 @@ namespace Plugin.Settings
         {
             get
             {
-                ISettings ret = implementation;
+                ISettings ret = Implementation;
                 if (ret == null)
                 {
                     throw NotImplementedInReferenceAssembly();
@@ -43,7 +43,7 @@ namespace Plugin.Settings
             }
 			set
 			{
-				_implementation = value;
+				implementation = value;
 			}
         }
 

--- a/src/Plugin.Settings/CrossSettings.shared.cs
+++ b/src/Plugin.Settings/CrossSettings.shared.cs
@@ -24,7 +24,11 @@ namespace Plugin.Settings
         /// <summary>
         /// Gets if the plugin is supported on the current platform.
         /// </summary>
-        public static bool IsSupported => implementation == null ? false : true;
+#if NETSTANDARD1_0 || NETSTANDARD2_0
+        public static bool IsSupported => false;
+#else
+		public static bool IsSupported => true;
+#endif
 
         /// <summary>
         /// Current plugin implementation to use

--- a/src/Plugin.Settings/CrossSettings.shared.cs
+++ b/src/Plugin.Settings/CrossSettings.shared.cs
@@ -18,9 +18,8 @@ namespace Plugin.Settings
     /// </summary>
     public static class CrossSettings
     {
-		static ISettings _implementation;
 
-		static ISettings implementation => _implementation ?? (_implementation = CreateSettings());
+		static ISettings implementation;
 
         /// <summary>
         /// Gets if the plugin is supported on the current platform.
@@ -34,7 +33,7 @@ namespace Plugin.Settings
         {
             get
             {
-                ISettings ret = implementation;
+                var ret = implementation ?? (implementation = CreateSettings());
                 if (ret == null)
                 {
                     throw NotImplementedInReferenceAssembly();
@@ -43,7 +42,7 @@ namespace Plugin.Settings
             }
 			set
 			{
-				_implementation = value;
+				implementation = value;
 			}
         }
 

--- a/src/Plugin.Settings/CrossSettings.shared.cs
+++ b/src/Plugin.Settings/CrossSettings.shared.cs
@@ -18,12 +18,14 @@ namespace Plugin.Settings
     /// </summary>
     public static class CrossSettings
     {
-        static Lazy<ISettings> implementation = new Lazy<ISettings>(() => CreateSettings(), System.Threading.LazyThreadSafetyMode.PublicationOnly);
+		static ISettings _implementation;
+
+		static ISettings implementation => _implementation ?? (_implementation = CreateSettings());
 
         /// <summary>
         /// Gets if the plugin is supported on the current platform.
         /// </summary>
-        public static bool IsSupported => implementation.Value == null ? false : true;
+        public static bool IsSupported => implementation == null ? false : true;
 
         /// <summary>
         /// Current plugin implementation to use
@@ -32,13 +34,17 @@ namespace Plugin.Settings
         {
             get
             {
-                ISettings ret = implementation.Value;
+                ISettings ret = implementation;
                 if (ret == null)
                 {
                     throw NotImplementedInReferenceAssembly();
                 }
                 return ret;
             }
+			set
+			{
+				_implementation = value;
+			}
         }
 
         static ISettings CreateSettings()


### PR DESCRIPTION
Changes Proposed in this pull request:
This removes the ```Lazy``` This has the benefit of letting you set the current implementation yourself. The entire Interface is pointless if you can't supply your own.